### PR TITLE
Update dependency version constraints

### DIFF
--- a/http-slim.cabal
+++ b/http-slim.cabal
@@ -53,7 +53,7 @@ Library
   -- note the test harness constraints should be kept in sync with these
   -- where dependencies are shared
   build-depends:
-      base          >= 4.6.0.0   && < 4.17
+      base          >= 4.6.0.0   && < 4.21
     , array         >= 0.3.0.2   && < 0.6
     , parsec        >= 2.0       && < 3.2
     , time          >= 1.1.2.3   && < 1.13
@@ -62,10 +62,10 @@ Library
     -- The following dependencies are refined by flags, but they should
     -- still be mentioned here on the top-level.
     , mtl           >= 2.0.0.0   && < 2.4
-    , network       >= 2.4       && < 3.2
-    , HsOpenSSL
-    , bytestring
-    , containers
+    , network       >= 2.4       && < 3.3
+    , HsOpenSSL                     < 0.12
+    , bytestring                    < 0.13
+    , containers                    < 0.8
 
   default-language: Haskell98
   default-extensions: FlexibleInstances

--- a/http-slim.cabal
+++ b/http-slim.cabal
@@ -15,7 +15,7 @@ Description:
   the older HTTP package. FastCGI interface is included as well.
 
 tested-with:
-  GHC==9.2.1, GHC==9.0.1,
+  GHC==9.6.6, GHC==9.2.1, GHC==9.0.1,
   GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2,
   GHC==7.10.3, GHC==7.8.4, GHC==7.6.3
 


### PR DESCRIPTION
This PR bumps up the upper bounds on dependency versions based on [Stackage nightly 2025-01-21](https://www.stackage.org/nightly-2025-01-21). I've verified that it builds successfully against GHC 9.6.6 on NixOS with the following package versions:
```
    Cabal-3.10.3.0
    Cabal-syntax-3.10.3.0
    array-0.5.6.0
    base-4.18.2.1
    binary-0.8.9.1
    bytestring-0.11.5.3
    containers-0.6.7
    deepseq-1.4.8.1
    directory-1.3.8.5
    exceptions-0.10.7
    filepath-1.4.300.1
    ghc-9.6.6
    ghc-bignum-1.3
    ghc-boot-9.6.6
    ghc-boot-th-9.6.6
    ghc-compact-0.1.0.0
    ghc-heap-9.6.6
    ghc-prim-0.10.0
    ghci-9.6.6
    haskeline-0.8.2.1
    hpc-0.6.2.0
    integer-gmp-1.1
    libiserv-9.6.6
    mtl-2.3.1
    parsec-3.1.16.1
    pretty-1.1.3.6
    process-1.6.19.0
    rts-1.0.2
    stm-2.5.1.0
    system-cxx-std-lib-1.0
    template-haskell-2.20.0.0
    terminfo-0.4.1.6
    text-2.0.2
    time-1.12.2
    transformers-0.6.1.0
    unix-2.8.4.0
    xhtml-3000.2.2.1
```
Additionally, I've verified that the gf compiler on the majestic branch builds successfully against it with the same package set.

I note that I've elected to leave the `Win32` version alone, as I do not have a way to test on Windows.